### PR TITLE
41 exon boundaries

### DIFF
--- a/PanelSearch/VV_Request_Parse.py
+++ b/PanelSearch/VV_Request_Parse.py
@@ -10,9 +10,23 @@ def vv_request_parse(vv_output, panel_dict):
         ID = vv_gene_record['hgnc']
         transcript = vv_gene_record['transcripts'][0]['reference']
 
+        exon_coords = []
+        exons_record = list(vv_gene_record['transcripts'][0]['genomic_spans'].values())[0]['exon_structure']
+        for exon_record in exons_record:
+            exon_no = exon_record['exon_number']
+            gen_start = exon_record['genomic_start']
+            gen_end = exon_record['genomic_end']
+            trans_start = exon_record['transcript_start']
+            trans_end = exon_record['transcript_end']
+
+            exon_coords.append({exon_no : [trans_start, trans_end, gen_start, gen_end]})
+        
+        #print(f'{exon_coords}\n\n')
+
         for gene_record in panel_dict['Genes']:
             if list(gene_record.keys())[0] == ID:
                 gene_record[ID].append(transcript)
+                gene_record[ID].append(exon_coords)
     
     return panel_dict
 

--- a/PanelSearch/generate_bed.py
+++ b/PanelSearch/generate_bed.py
@@ -20,13 +20,16 @@ logging.basicConfig(
     ]
 )
 
-def parse_panel_data(json_data):
+def parse_panel_data(json_data, coord_type):
     """
     Parses panel data from JSON and extracts gene information.
 
     Args:
         json_data (str): JSON string containing panel data.
 
+        coord_type (str): string specifying whether the user wants
+                          genomic or transcript coordiantes in the
+                          produced bed file.
     Returns:
         list: List of dictionaries representing BED data.
     """
@@ -53,6 +56,12 @@ def parse_panel_data(json_data):
             bed['chromosome'] = chr
             bed['gene'] = symbol
             bed['transcript'] = transcript
+
+            if coord_type == 'trans':
+                bed['coordinates'] = 'transcript'
+            elif coord_type == 'gen':
+                bed['coordinates'] = 'genomic'
+
             bed['exons'] = []
 
             for exon in info[4]:
@@ -61,8 +70,12 @@ def parse_panel_data(json_data):
 
                 for k, v in exon.items():
                     exon_bed['exon_no'] = k
-                    exon_bed['start'] = v[0] # Do we need to adjust for zero-based indexing
-                    exon_bed['end'] = v[1]
+                    if coord_type == 'trans':
+                        exon_bed['start'] = v[0] # Do we need to adjust for zero-based indexing
+                        exon_bed['end'] = v[1]
+                    elif coord_type == 'gen':
+                        exon_bed['start'] = str(int(v[2]) - 1)
+                        exon_bed['end'] = str(int(v[3]) - 1)
                 
                 bed['exons'].append(exon_bed)
             
@@ -70,7 +83,7 @@ def parse_panel_data(json_data):
                 
     return beds
 
-def write_bed_file(beds, filename):
+def write_bed_file(beds, filename, coord_type):
     """
     Writes BED data to a file in both BED and JSON formats.
 
@@ -78,18 +91,27 @@ def write_bed_file(beds, filename):
         beds (list): List of BED data.
         filename (str): Filename for the output BED file.
 
+        coord_type(str): The type of coordinates, genomic or
+                         transcript, used to generate the bed
+                         file. 
     Returns:
         tuple: (bool, str) Indicates success status and message.
     """
     try:
         # Write to BED file
         with open(filename, 'w') as file:
-            headline = 'chromosome\tstart\tend\ttranscript\tgene\texon'
+            if coord_type == 'trans':
+                headline = 'chromosome\tstart\tend\ttranscript\tgene\texon'
+            elif coord_type == 'gen':
+                headline = 'chromosome\tstart\tend\tgene\texon'
             file.write(headline)
             
             for bed in beds:
                 for exon in bed['exons']:
-                    line = f"\n{bed['chromosome']}\t{exon['start']}\t{exon['end']}\t{bed['transcript']}\t{bed['gene']}\t{exon['exon_no']}"
+                    if coord_type == 'trans':
+                        line = f"\n{bed['chromosome']}\t{exon['start']}\t{exon['end']}\t{bed['transcript']}\t{bed['gene']}\t{exon['exon_no']}"
+                    elif coord_type == 'gen':
+                        line = f"\n{bed['chromosome']}\t{exon['start']}\t{exon['end']}\t{bed['gene']}\t{exon['exon_no']}"
                     file.write(line)
 
         # Write to JSON file
@@ -116,8 +138,19 @@ def main():
     try:
         printed_panel_json = sys.argv[1]
         filename = sys.argv[2]
-        beds = parse_panel_data(printed_panel_json)
-        write_bed_file(beds, filename)
+        
+        coord_type_no = ''
+        while coord_type_no != '1' and coord_type_no != '2':
+            coord_type_no = input('For exon coordinates on transcript, press \'1\'. For genomic coordinates, press \'2\'.')
+            if coord_type_no == '1':
+                coord_type = 'trans'
+            elif coord_type_no == '2':
+                coord_type = 'gen'
+            else:
+                print('Invalid input - try again')
+
+        beds = parse_panel_data(printed_panel_json, coord_type)
+        write_bed_file(beds, filename, coord_type)
     except Exception as e:
         logging.error(f"Unexpected error: {e}")
         sys.exit(1)


### PR DESCRIPTION
I have extracted exon boundary coordinates and numbers from the VV API output and added to the json and .bed files created by the generate_bed.py. The script will now ask the user whether they wish to have the coordinates in the bed file and json as the coordinates within the identified mane_select transcript or genomic coordinates using their chosen genome build. Which they choose will determine the layout of the bedfile produced (the transcript won't be listed if genomic coords are requested).